### PR TITLE
Imgui Implementation - Imgui main into renderer.

### DIFF
--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -10,6 +10,7 @@ set(Header_Files
     "USDScene.h"
     "RenderMesh.h"
     "StaticMeshPipeline.h"
+    "ImGuiDescHeap.h"
 )
 source_group("Header Files" FILES ${Header_Files})
 
@@ -20,6 +21,7 @@ set(Source_Files
     "USDScene.cpp"
     "RenderMesh.cpp"
     "StaticMeshPipeline.cpp"
+    "ImGuiDescHeap.cpp"
 )
 source_group("Source Files" FILES ${Source_Files})
 

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -160,6 +160,10 @@ target_link_libraries(${PROJECT_NAME} PRIVATE TBB::tbb)
 # NVTX
 target_link_libraries(${PROJECT_NAME} PRIVATE nvtx3-cpp)
 
+# IMGUI
+find_package(imgui CONFIG REQUIRED)
+target_link_libraries(${PROJECT_NAME} PRIVATE imgui::imgui)
+  
 # USD
 find_package(pxr CONFIG REQUIRED)
 target_link_libraries(${PROJECT_NAME} PRIVATE

--- a/Src/CMakeLists.txt
+++ b/Src/CMakeLists.txt
@@ -6,22 +6,22 @@ set(PROJECT_NAME DXRenderer)
 set(Header_Files
     "MainWindow.h"
     "pch.h"
+    "ImGuiDescHeap.h"
     "Renderer.h"
     "USDScene.h"
     "RenderMesh.h"
     "StaticMeshPipeline.h"
-    "ImGuiDescHeap.h"
 )
 source_group("Header Files" FILES ${Header_Files})
 
 set(Source_Files
     "DXRenderer.cpp"
+    "ImGuiDescHeap.cpp"
     "Renderer.cpp"
     "MainWindow.cpp"
     "USDScene.cpp"
     "RenderMesh.cpp"
     "StaticMeshPipeline.cpp"
-    "ImGuiDescHeap.cpp"
 )
 source_group("Source Files" FILES ${Source_Files})
 

--- a/Src/ImGuiDescHeap.cpp
+++ b/Src/ImGuiDescHeap.cpp
@@ -1,0 +1,38 @@
+
+#include "ImGuiDescHeap.h"
+#include <d3d12.h>
+#include "imgui.h"
+
+void ImguiDescHeapAllocator::Create(ID3D12Device* device, ID3D12DescriptorHeap* heap)
+{
+    IM_ASSERT(Heap == nullptr && FreeIndices.empty());
+    Heap = heap;
+    D3D12_DESCRIPTOR_HEAP_DESC desc = heap->GetDesc();
+    HeapType = desc.Type;
+    HeapStartCpu = Heap->GetCPUDescriptorHandleForHeapStart();
+    HeapStartGpu = Heap->GetGPUDescriptorHandleForHeapStart();
+    HeapHandleIncrement = device->GetDescriptorHandleIncrementSize(HeapType);
+    FreeIndices.reserve((int)desc.NumDescriptors);
+    for (int n = desc.NumDescriptors; n > 0; n--)
+        FreeIndices.push_back(n - 1);
+}
+void ImguiDescHeapAllocator::Destroy()
+{
+    Heap = nullptr;
+    FreeIndices.clear();
+}
+void ImguiDescHeapAllocator::Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle)
+{
+    IM_ASSERT(FreeIndices.Size > 0);
+    int idx = FreeIndices.back();
+    FreeIndices.pop_back();
+    out_cpu_desc_handle->ptr = HeapStartCpu.ptr + (idx * HeapHandleIncrement);
+    out_gpu_desc_handle->ptr = HeapStartGpu.ptr + (idx * HeapHandleIncrement);
+}
+void ImguiDescHeapAllocator::Free(D3D12_CPU_DESCRIPTOR_HANDLE out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE out_gpu_desc_handle)
+{
+    int cpu_idx = (int)((out_cpu_desc_handle.ptr - HeapStartCpu.ptr) / HeapHandleIncrement);
+    int gpu_idx = (int)((out_gpu_desc_handle.ptr - HeapStartGpu.ptr) / HeapHandleIncrement);
+    IM_ASSERT(cpu_idx == gpu_idx);
+    FreeIndices.push_back(cpu_idx);
+}

--- a/Src/ImGuiDescHeap.cpp
+++ b/Src/ImGuiDescHeap.cpp
@@ -16,11 +16,13 @@ void ImguiDescHeapAllocator::Create(ID3D12Device* device, ID3D12DescriptorHeap* 
     for (int n = desc.NumDescriptors; n > 0; n--)
         FreeIndices.push_back(n - 1);
 }
+
 void ImguiDescHeapAllocator::Destroy()
 {
     Heap = nullptr;
     FreeIndices.clear();
 }
+
 void ImguiDescHeapAllocator::Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle)
 {
     IM_ASSERT(FreeIndices.Size > 0);
@@ -29,6 +31,7 @@ void ImguiDescHeapAllocator::Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_han
     out_cpu_desc_handle->ptr = HeapStartCpu.ptr + (idx * HeapHandleIncrement);
     out_gpu_desc_handle->ptr = HeapStartGpu.ptr + (idx * HeapHandleIncrement);
 }
+
 void ImguiDescHeapAllocator::Free(D3D12_CPU_DESCRIPTOR_HANDLE out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE out_gpu_desc_handle)
 {
     int cpu_idx = (int)((out_cpu_desc_handle.ptr - HeapStartCpu.ptr) / HeapHandleIncrement);

--- a/Src/ImGuiDescHeap.cpp
+++ b/Src/ImGuiDescHeap.cpp
@@ -3,18 +3,18 @@
 #include <d3d12.h>
 #include "imgui.h"
 
-void ImguiDescHeapAllocator::Create(ID3D12Device* device, ID3D12DescriptorHeap* heap)
+void ImguiDescHeapAllocator::Create(ID3D12Device* InDevice, ID3D12DescriptorHeap* InHeap)
 {
     IM_ASSERT(Heap == nullptr && FreeIndices.empty());
-    Heap = heap;
-    D3D12_DESCRIPTOR_HEAP_DESC desc = heap->GetDesc();
-    HeapType = desc.Type;
+    Heap = InHeap;
+    D3D12_DESCRIPTOR_HEAP_DESC Desc = InHeap->GetDesc();
+    HeapType = Desc.Type;
     HeapStartCpu = Heap->GetCPUDescriptorHandleForHeapStart();
     HeapStartGpu = Heap->GetGPUDescriptorHandleForHeapStart();
-    HeapHandleIncrement = device->GetDescriptorHandleIncrementSize(HeapType);
-    FreeIndices.reserve((int)desc.NumDescriptors);
-    for (int n = desc.NumDescriptors; n > 0; n--)
-        FreeIndices.push_back(n - 1);
+    HeapHandleIncrement = InDevice->GetDescriptorHandleIncrementSize(HeapType);
+    FreeIndices.reserve(static_cast<int>(Desc.NumDescriptors));
+    for (int N = static_cast<int>(Desc.NumDescriptors); N > 0; N--)
+        FreeIndices.push_back(N - 1);
 }
 
 void ImguiDescHeapAllocator::Destroy()
@@ -26,16 +26,16 @@ void ImguiDescHeapAllocator::Destroy()
 void ImguiDescHeapAllocator::Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle)
 {
     IM_ASSERT(FreeIndices.Size > 0);
-    int idx = FreeIndices.back();
+    const size_t Idx = FreeIndices.back();
     FreeIndices.pop_back();
-    out_cpu_desc_handle->ptr = HeapStartCpu.ptr + (idx * HeapHandleIncrement);
-    out_gpu_desc_handle->ptr = HeapStartGpu.ptr + (idx * HeapHandleIncrement);
+    out_cpu_desc_handle->ptr = HeapStartCpu.ptr + (Idx * HeapHandleIncrement);
+    out_gpu_desc_handle->ptr = HeapStartGpu.ptr + (Idx * HeapHandleIncrement);
 }
 
 void ImguiDescHeapAllocator::Free(D3D12_CPU_DESCRIPTOR_HANDLE out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE out_gpu_desc_handle)
 {
-    int cpu_idx = (int)((out_cpu_desc_handle.ptr - HeapStartCpu.ptr) / HeapHandleIncrement);
-    int gpu_idx = (int)((out_gpu_desc_handle.ptr - HeapStartGpu.ptr) / HeapHandleIncrement);
+    size_t cpu_idx = (out_cpu_desc_handle.ptr - HeapStartCpu.ptr) / HeapHandleIncrement;
+    size_t gpu_idx = (out_gpu_desc_handle.ptr - HeapStartGpu.ptr) / HeapHandleIncrement;
     IM_ASSERT(cpu_idx == gpu_idx);
-    FreeIndices.push_back(cpu_idx);
+    FreeIndices.push_back(static_cast<int>(cpu_idx));
 }

--- a/Src/ImGuiDescHeap.h
+++ b/Src/ImGuiDescHeap.h
@@ -13,7 +13,7 @@ struct ImguiDescHeapAllocator
     UINT                        HeapHandleIncrement;
     ImVector<int>               FreeIndices;
 
-    void Create(ID3D12Device* device, ID3D12DescriptorHeap* heap);
+    void Create(ID3D12Device* InDevice, ID3D12DescriptorHeap* InHeap);
 
     void Destroy();
     void Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle);

--- a/Src/ImGuiDescHeap.h
+++ b/Src/ImGuiDescHeap.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "imgui.h"
+#include <d3d12.h>
+
+// Imgui desct heap - Simple free list based allocator
+struct ImguiDescHeapAllocator
+{
+    ID3D12DescriptorHeap*       Heap = nullptr;
+    D3D12_DESCRIPTOR_HEAP_TYPE  HeapType = D3D12_DESCRIPTOR_HEAP_TYPE_NUM_TYPES;
+    D3D12_CPU_DESCRIPTOR_HANDLE HeapStartCpu;
+    D3D12_GPU_DESCRIPTOR_HANDLE HeapStartGpu;
+    UINT                        HeapHandleIncrement;
+    ImVector<int>               FreeIndices;
+
+    void Create(ID3D12Device* device, ID3D12DescriptorHeap* heap);
+
+    void Destroy();
+    void Alloc(D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle);
+    void Free(D3D12_CPU_DESCRIPTOR_HANDLE out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE out_gpu_desc_handle);
+};

--- a/Src/MainWindow.cpp
+++ b/Src/MainWindow.cpp
@@ -19,6 +19,11 @@
 // NVTX
 #include <nvtx3/nvtx3.hpp>
 
+// Imgui
+#include "imgui.h"
+#include "imgui_impl_win32.h"
+#include "imgui_impl_dx12.h"
+
 
 MainWindow::MainWindow(HINSTANCE InHInstance)
 {
@@ -27,6 +32,8 @@ MainWindow::MainWindow(HINSTANCE InHInstance)
     G_MainWindow = this;
     hInstance = InHInstance;
 
+    InitImgui();
+    
     Scene = std::make_unique<USDScene>();
     RendererDX = std::make_unique<Renderer>();
 }
@@ -124,6 +131,15 @@ bool MainWindow::SetupWindow(const UINT& DefaultWidth, const UINT& DefaultHeight
 
     bResult = true;
     return bResult;
+}
+
+void MainWindow::InitImgui()
+{
+    IMGUI_CHECKVERSION();
+    Imgui_Context = ImGui::CreateContext();
+    Imgui_Io = ImGui::GetIO();
+    Imgui_Io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    Imgui_Io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 }
 
 int MainWindow::Run()

--- a/Src/MainWindow.cpp
+++ b/Src/MainWindow.cpp
@@ -70,39 +70,11 @@ LRESULT CALLBACK MainWindow::WinProcedure(HWND hWnd, UINT message, WPARAM wParam
     case WM_SIZE:
         if (G_MainWindow->RendererDX->Device != nullptr && wParam != SIZE_MINIMIZED)
         {
-            // UINT Width = LOWORD(lParam) * G_MainWindow->DpiScaling;
-            // UINT Height = HIWORD(lParam) * G_MainWindow->DpiScaling;
-            //
-            // std::wstring Title = _T("Win D3D Renderer - Mooncake | ");
-            // Title.append(std::to_wstring(Width));
-            // Title.append(_T("x"));
-            // Title.append(std::to_wstring(Height));
-            //
-            // SetWindowText(hWnd, Title.c_str());
-            //
-            // G_MainWindow->RendererDX->WaitForPreviousFrame();
-            //
-            // G_MainWindow->RendererDX->AspectRatio = static_cast<float>(Width) / static_cast<float>(Height);
-            // G_MainWindow->RendererDX->Width = Width;
-            // G_MainWindow->RendererDX->Height = Height;
-            //
-            // G_MainWindow->RendererDX->Viewport.Height = Height;
-            // G_MainWindow->RendererDX->Viewport.Width = Width;
-            //
-            // DXGI_SWAP_CHAIN_DESC desc = {};
-            // G_MainWindow->RendererDX->SwapChain->GetDesc(&desc);
-            //
-            // G_MainWindow->RendererDX->CleanupFrameBuffers();
-            // HRESULT result = G_MainWindow->RendererDX->SwapChain->ResizeBuffers(desc.BufferCount, Width, Height, desc.BufferDesc.Format, desc.Flags);
-            // assert(SUCCEEDED(result) && "Failed to resize swapchain.");
-            // G_MainWindow->RendererDX->CreateFrameBuffers();
+            UINT Width = LOWORD(lParam) * G_MainWindow->DpiScaling;
+            UINT Height = HIWORD(lParam) * G_MainWindow->DpiScaling;
+            //G_MainWindow->RendererDX->ResizeFrameBuffers(Width, Height);
+            break;
         }        
-        
-    // case WM_PAINT:
-    //     //G_MainWindow->RendererDX->Update();
-    //     //G_MainWindow->RendererDX->Render();
-    //
-    //     break;
 
     default:
         return DefWindowProc(hWnd, message, wParam, lParam);

--- a/Src/MainWindow.cpp
+++ b/Src/MainWindow.cpp
@@ -72,7 +72,7 @@ LRESULT CALLBACK MainWindow::WinProcedure(HWND hWnd, UINT message, WPARAM wParam
         {
             UINT Width = LOWORD(lParam) * G_MainWindow->DpiScaling;
             UINT Height = HIWORD(lParam) * G_MainWindow->DpiScaling;
-            //G_MainWindow->RendererDX->ResizeFrameBuffers(Width, Height);
+            G_MainWindow->RendererDX->QueueResize(Width, Height);
             break;
         }        
 

--- a/Src/MainWindow.cpp
+++ b/Src/MainWindow.cpp
@@ -40,12 +40,20 @@ MainWindow::MainWindow(HINSTANCE InHInstance)
 
 MainWindow::~MainWindow()
 {
+    ImGui_ImplDX12_Shutdown();
+    ImGui_ImplWin32_Shutdown();
+    ImGui::DestroyContext();
+    
     G_MainWindow = nullptr;
 }
 
 LRESULT CALLBACK MainWindow::WinProcedure(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 {
     nvtx3::scoped_range r{ "WinProcedure" };
+
+    extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+    if (ImGui_ImplWin32_WndProcHandler(hWnd, message, wParam, lParam))
+        return true;
 
     switch (message)
     {
@@ -136,10 +144,11 @@ bool MainWindow::SetupWindow(const UINT& DefaultWidth, const UINT& DefaultHeight
 void MainWindow::InitImgui()
 {
     IMGUI_CHECKVERSION();
-    Imgui_Context = ImGui::CreateContext();
-    Imgui_Io = ImGui::GetIO();
-    Imgui_Io.ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
-    Imgui_Io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
+    //Imgui_Context = ImGui::CreateContext();
+    ImGui::CreateContext();
+    Imgui_Io = &ImGui::GetIO();
+    Imgui_Io->ConfigFlags |= ImGuiConfigFlags_NavEnableKeyboard;     // Enable Keyboard Controls
+    Imgui_Io->ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;      // Enable Gamepad Controls
 }
 
 int MainWindow::Run()

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -38,6 +38,8 @@ public:
     const double& GetTime() const { return Time; } 
     bool SetupWindow();
 
+    const float& GetDpiScale() const { return DpiScaling; } 
+
 private:
     bool InitImgui();
 

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -39,7 +39,7 @@ public:
     bool SetupWindow(const UINT& DefaultWidth, const UINT& DefaultHeight);
 
 private:
-    void InitImgui();
+    bool InitImgui();
 
 public:
     // App Global Classes, can be accessed through G_MainWindow
@@ -55,6 +55,10 @@ private:
     // Windows Ptrs
     HINSTANCE hInstance = nullptr;
     HWND hWnd = nullptr;
+
+    // UI General
+    float DpiScaling = 1.0f;
+    float ImguiUIScaling = 1.5f;
 
     // Timing
     double Time = 0.0;

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -43,7 +43,7 @@ public:
 
     // Imgui Globals
     struct ImguiContext* Imgui_Context;
-    struct ImGuiIO& Imgui_Io;
+    struct ImGuiIO* Imgui_Io;
     
 private:
 

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -36,7 +36,7 @@ public:
     HWND& GetHWND() { return hWnd; }
 
     const double& GetTime() const { return Time; } 
-    bool SetupWindow(const UINT& DefaultWidth, const UINT& DefaultHeight);
+    bool SetupWindow();
 
 private:
     bool InitImgui();
@@ -58,7 +58,7 @@ private:
 
     // UI General
     float DpiScaling = 1.0f;
-    float ImguiUIScaling = 1.5f;
+    float ImguiUIScaling = 1.0f;
 
     // Timing
     double Time = 0.0;

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -15,7 +15,12 @@
 #include <dxgi1_6.h>
 #include <memory>
 
+#include "ImGuiDescHeap.h"
+
 using Microsoft::WRL::ComPtr; // Import only the ComPtr
+
+inline ImguiDescHeapAllocator ImguiHeapAlloc;
+
 
 class MainWindow
 {

--- a/Src/MainWindow.h
+++ b/Src/MainWindow.h
@@ -33,10 +33,17 @@ public:
     const double& GetTime() const { return Time; } 
     bool SetupWindow(const UINT& DefaultWidth, const UINT& DefaultHeight);
 
+private:
+    void InitImgui();
+
 public:
     // App Global Classes, can be accessed through G_MainWindow
     std::unique_ptr<class Renderer> RendererDX;
     std::unique_ptr<class USDScene> Scene;
+
+    // Imgui Globals
+    struct ImguiContext* Imgui_Context;
+    struct ImGuiIO& Imgui_Io;
     
 private:
 

--- a/Src/Renderer.cpp
+++ b/Src/Renderer.cpp
@@ -9,6 +9,11 @@
 
 #include <nvtx3/nvtx3.hpp>
 
+// Imgui
+#include "imgui.h"
+#include "imgui_impl_win32.h"
+#include "imgui_impl_dx12.h"
+
 // Define SDK version.
 // Requires the Microsoft.Direct3D.D3D12 package (from nuget), version is the middle number of the version: '1.615.1'
 extern "C" { __declspec(dllexport) extern const UINT D3D12SDKVersion = 615; } 
@@ -47,7 +52,19 @@ bool Renderer::Setup()
     if (!SetupMeshRootSignature())                  { return false; }
     
     SMPipe = std::make_unique<StaticMeshPipeline>(this);
-       
+
+    // Setup Platform/Renderer backends
+    ImGui_ImplDX12_InitInfo init_info = {};
+    init_info.Device = Device.Get();
+    init_info.CommandQueue = CmdQueue.Get();
+    init_info.NumFramesInFlight = FrameBufferCount;
+    init_info.RTVFormat = FrameBufferFormat; 
+    init_info.SrvDescriptorHeap = FrameBufferHeap.Get();
+    init_info.SrvDescriptorAllocFn = [](ImGui_ImplDX12_InitInfo*, D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_handle) { return YOUR_ALLOCATOR_FUNCTION_FOR_SRV_DESCRIPTORS(...); };
+    init_info.SrvDescriptorFreeFn = [](ImGui_ImplDX12_InitInfo*, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle)            { return YOUR_FREE_FUNCTION_FOR_SRV_DESCRIPTORS(...); };
+
+
+    
     // DX Setup correctly.
     bDXReady = true;
     return bDXReady;

--- a/Src/Renderer.cpp
+++ b/Src/Renderer.cpp
@@ -414,9 +414,9 @@ void Renderer::EndFrame()
     CmdListEndFrame->SetName(L"CmdList-EndFrame");
 
     // Imgui Rendering
-    // (Your code clears your framebuffer, renders your other stuff etc.)
-    
+    SetBackBufferOM(CmdListEndFrame); // Imgui requires the output merger.
     CmdListEndFrame->SetDescriptorHeaps(1, SrvBufferHeap.GetAddressOf());
+    ImGui::EndFrame();
     ImGui::Render();
     ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), CmdListEndFrame.Get());    
 

--- a/Src/Renderer.cpp
+++ b/Src/Renderer.cpp
@@ -188,7 +188,7 @@ bool Renderer::SetupSwapChain()
     SwapChainDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
     
     // SWAP CHAIN WAS SCALING BACK BUFFERS TO FIT WINDOW SIZE - CAUSING IMGUI TO NOT LINE UP.
-    //SwapChainDesc.Scaling = DXGI_SCALING_NONE; // Disabling scaling.
+    SwapChainDesc.Scaling = DXGI_SCALING_NONE; // Disabling scaling.
     if (!VSyncEnabled) { SwapChainDesc.Flags |= DXGI_SWAP_CHAIN_FLAG_ALLOW_TEARING; }
     
     ComPtr<IDXGISwapChain1> BaseSwapChain;

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -63,6 +63,7 @@ private:
 
     //Utils
     bool SetupImguiRendering();
+    void CalculateAspectRatio() { AspectRatio = static_cast<float>(Width) / static_cast<float>(Height); };
 
 public:
     // Pipelines
@@ -78,8 +79,8 @@ public:
     float FarPlane = 100.0f;
 
     float FieldOfView = 45.0;
-    float AspectRatio = static_cast<float>(Width) / static_cast<float>(Height);
-
+    float AspectRatio = 1.0f; // Gets calculated on init.
+ 
     float MaxDepth = 1.0f;
     
     // DX resources.

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -20,6 +20,7 @@
 
 using Microsoft::WRL::ComPtr; // Import only the ComPtr
 
+
 struct Vertex
 {
     DirectX::XMFLOAT3 Position;
@@ -50,9 +51,6 @@ private:
     bool SetupDevice();
     bool SetupSwapChain();
     bool SetupMeshRootSignature();
-
-    void ImGuiHeapAlloc(struct ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle);
-    void ImGuiHeapFree(struct ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle);
 
     // Frame Stages
     // From https://github.com/microsoft/DirectX-Graphics-Samples/blob/master/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -123,7 +121,7 @@ public:
     CB_WVP WVP; // World View Projection buffer.
 
     // Imgui
-    static std::shared_ptr<struct ImguiDescHeapAllocator> ImguiHeapAlloc;
+    //static ImguiDescHeapAllocator ImguiHeapAlloc;
     ComPtr<ID3D12DescriptorHeap> SrvBufferHeap;
 
     

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -34,7 +34,9 @@ public:
     // Create/Clean/Resize RTs for the frame buffers
     bool CreateFrameBuffers();
     void CleanupFrameBuffers();
-    void ResizeFrameBuffers(int InWidth, int InHeight);
+    bool CreateDepthStencilResource();
+    void CleanupDepthStencilBuffer();
+    void ResizeFrameBuffers();
     
     // Main render loop.
     void Update();
@@ -45,6 +47,7 @@ public:
 
     // Utilities
     void SetBackBufferOM(ComPtr<ID3D12GraphicsCommandList>& InCmdList) const;
+    void QueueResize(UINT InWidth, UINT InHeight);
 
 private:
     // Setup Helpers
@@ -79,9 +82,6 @@ public:
 
     float MaxDepth = 1.0f;
     
-    // Render State
-    bool bDXReady = false;
-
     // DX resources.
     ComPtr<ID3D12Debug> DebugController;
     ComPtr<IDXGIDebug1> DebugDXGI;
@@ -125,5 +125,14 @@ public:
     // Imgui
     ComPtr<ID3D12DescriptorHeap> SrvBufferHeap;
 
+private:
+
+    // Render State
+    bool bDXReady = false;
+    bool bResizeQueued = false;
+
+    // Pending Resize Widths
+    int NewResizeWidth = 0;
+    int NewResizeHeight = 0;
     
 };

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -32,10 +32,14 @@ class Renderer
 {
 public:
     ~Renderer();
-    
+
     // Rendering Setup
     bool Setup();
-
+    
+    // Create/Clean RTs for the frame buffers
+    bool CreateFrameBuffers();
+    void CleanupFrameBuffers();
+    
     // Main render loop.
     void Update();
     void Render();
@@ -58,6 +62,8 @@ private:
     void MidFrame();
     void EndFrame();
 
+    //Utils
+    bool SetupImguiRendering();
 
 public:
     // Pipelines
@@ -67,8 +73,8 @@ public:
     bool VSyncEnabled = true;
     
     // Window and Viewport Properties
-    UINT Width = 800;
-    UINT Height = 600;
+    UINT Width = 2560;
+    UINT Height = 1440;
     float NearPlane = 0.01f; // Can't be zero for depth buffer.
     float FarPlane = 100.0f;
 

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -31,9 +31,10 @@ public:
     // Rendering Setup
     bool Setup();
     
-    // Create/Clean RTs for the frame buffers
+    // Create/Clean/Resize RTs for the frame buffers
     bool CreateFrameBuffers();
     void CleanupFrameBuffers();
+    void ResizeFrameBuffers(int InWidth, int InHeight);
     
     // Main render loop.
     void Update();

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -16,6 +16,7 @@
 #include <dxgi1_6.h>
 #include <memory>
 
+#include "ImGuiDescHeap.h"
 
 using Microsoft::WRL::ComPtr; // Import only the ComPtr
 
@@ -49,6 +50,9 @@ private:
     bool SetupDevice();
     bool SetupSwapChain();
     bool SetupMeshRootSignature();
+
+    void ImGuiHeapAlloc(struct ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE* out_cpu_desc_handle, D3D12_GPU_DESCRIPTOR_HANDLE* out_gpu_desc_handle);
+    void ImGuiHeapFree(struct ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE cpu_handle, D3D12_GPU_DESCRIPTOR_HANDLE gpu_handle);
 
     // Frame Stages
     // From https://github.com/microsoft/DirectX-Graphics-Samples/blob/master/Samples/Desktop/D3D12Multithreading/src/D3D12Multithreading.cpp
@@ -118,4 +122,9 @@ public:
     // World Constants
     CB_WVP WVP; // World View Projection buffer.
 
+    // Imgui
+    static std::shared_ptr<struct ImguiDescHeapAllocator> ImguiHeapAlloc;
+    ComPtr<ID3D12DescriptorHeap> SrvBufferHeap;
+
+    
 };

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -75,7 +75,6 @@ public:
 
     float MaxDepth = 1.0f;
     
-    
     // Render State
     bool bDXReady = false;
 

--- a/Src/Renderer.h
+++ b/Src/Renderer.h
@@ -3,23 +3,18 @@
 
 // Common
 #include <wrl/client.h>
-#include <stdlib.h>
 #include <vector>
 
 #include "pch.h"
 #include "StaticMeshPipeline.h"
 
 // DX
-#include <d3dcommon.h>
 #include <dxgidebug.h>
 #include <d3d12.h>
 #include <dxgi1_6.h>
 #include <memory>
 
-#include "ImGuiDescHeap.h"
-
 using Microsoft::WRL::ComPtr; // Import only the ComPtr
-
 
 struct Vertex
 {
@@ -73,8 +68,8 @@ public:
     bool VSyncEnabled = true;
     
     // Window and Viewport Properties
-    UINT Width = 2560;
-    UINT Height = 1440;
+    UINT Width = 800;
+    UINT Height = 600;
     float NearPlane = 0.01f; // Can't be zero for depth buffer.
     float FarPlane = 100.0f;
 
@@ -127,7 +122,6 @@ public:
     CB_WVP WVP; // World View Projection buffer.
 
     // Imgui
-    //static ImguiDescHeapAllocator ImguiHeapAlloc;
     ComPtr<ID3D12DescriptorHeap> SrvBufferHeap;
 
     

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,11 @@
   "dependencies": [
     "directx12-agility",
     "tbb",
-    "usd"
+    "usd",
+    {
+      "name" : "imgui",
+      "features" : ["dx12-binding", "win32-binding"]
+    }
   ],
   "overrides": [
     {


### PR DESCRIPTION
Just show the demo window. Handles setup and scaling of the windows and framebuffers. This is the main imgui branch, instead of docking, which will require another pull/build.

This has an issue where "ImGui::GetIO().DisplayFramebufferScale" doesn't scale with the UI, so swapchain scaling breaks the mapping between imgui interaction and imgui rendering. This is fixed with some custom scaling that is applied based on the viewport and DPI. Possibly the docking branch fixes this, or future imgui updates will fix this.